### PR TITLE
Work on --imaplist formatting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ What has been done since last release
 
   * The CLI interface is now implemented with docopt
   * The README now includes the documentation
-  * New command --imaplist lists the directories in IMAP account (to polish)
+  * New command --imaplist lists the directories in IMAP account
   * Code now follows PEP-8 style guide
   * Renamed variables to be consistent
   * Added gmail integration (thanks to Orkim!)

--- a/isbg.py
+++ b/isbg.py
@@ -418,10 +418,9 @@ res = imap.login(imapuser, imappasswd)
 assertok(res, "login", imapuser, 'xxxxxxxx')
 
 # List imap directories
-# TODO Format output
 if opts["--imaplist"] is True:
     imap_list = str(imap.list())
-    imap_list = re.sub('\(.*?\)| \".\" \"|\"\', \''," ",imap_list)
+    imap_list = re.sub('\(.*?\)| \".\" \"|\"\', \''," ",imap_list) # string formatting
     print(imap_list)
 
 # Spamassassin training

--- a/isbg.py
+++ b/isbg.py
@@ -420,7 +420,9 @@ assertok(res, "login", imapuser, 'xxxxxxxx')
 # List imap directories
 # TODO Format output
 if opts["--imaplist"] is True:
-    print(imap.list())
+    imap_list = str(imap.list())
+    imap_list = re.sub('\(.*?\)| \".\" \"|\"\', \''," ",imap_list)
+    print(imap_list)
 
 # Spamassassin training
 if opts["--learnspambox"] is not None:


### PR DESCRIPTION
Instead of a raw dump of the imap flag, --imaplist now lists a more readable list. There is still work to do on this, mainly since --imaplist's error code is not right (assertok).