### PR TITLE
Enable proxyauth and fix some small typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ Options:
     --imappasswd passwd  IMAP account password
     --imapport port      Use a custom port
     --imapuser username  Who you login as
+    --imapproxyuser userbox     Use proxyauth on IMAP host. If set, allows
+                         the sysadmin or a secretary (identified by username
+                         and passwd above) to log into the IMAP server and
+                         administer the userbox account specified here.
+                         Otherwise the username accesses his or her own box.
+                         Required by Sun/iPlanet/Netscape IMAP servers to
+                         be able to use an administrative user.
     --imapinbox mbox     Name of your inbox folder
     --learnspambox mbox  Name of your learn spam folder
     --learnhambox mbox   Name of your learn ham folder
@@ -278,6 +285,32 @@ To run isbg for multiple accounts one after another, it is possible to use
 bash scripts like the ones in the folder "bash_scripts". Since these scripts
 contain passwords and are thus sensitive data, make sure the file permissions
 are very restrictive.
+
+# Proxy authentication<a name="Proxy-auth"></a>
+
+Many IMAP servers support a `PROXYAUTH` command so that the authenticated
+session can access another mailbox (assuming that access rights are set up
+on the server accordingly). Main use-case of this is when server or domain
+administrators (or similar mail-system accounts) undertake some maintenance
+activities in users' mailboxes, such as learning from email that users have
+put into their `Spam` or `Junk` folders, or running over unsorted email in
+the `INBOX` to re-classify and sort away possible spam missed earlier.
+Another common use-case is when an administrative aide or a secretary does
+some work in the big boss's mailbox on his or her behalf.
+
+The `isbg` supports IMAP Proxy Authentication using the following command
+line pattern:
+
+````
+$ ./isbg.py --imapuser mailadmin --imappasswd Adm1nPaSs \
+    --imaphost imap.domain.com --imapproxyuser enduser@domain.com --imaplist
+
+  "/" INBOX', '  "/" Drafts', '  "/" Junk', '  "/" Sent', '  "/" trusted'])
+````
+
+Here the `--imapuser` and `--imappasswd` still refer to the account you log in
+as (but this time it is the administrative account), and the `--imapproxyuser`
+refers to the end-user whose mailbox you administer.
 
 # Saving your password<a name="Saving-your-password"></a>
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Options:
     --teachonly          Don't search spam, just learn from folders
     --trackfile file     Override the trackfile name
     --verbose            Show IMAP stuff happening
+    --verbose-sa         Show SpamAssassin stuff happening
     --version            Show the version information
 
     (Your inbox will remain untouched unless you specify --flag or --delete)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Options:
     --savepw             Store the password to be used in future runs
     --spamc              Use spamc instead of standalone SpamAssassin binary
     --spaminbox mbox     Name of your spam folder
+    --createspaminbox    Enable creation of the spam folder if missing
     --nossl              Don't use SSL to connect to the IMAP server
     --teachonly          Don't search spam, just learn from folders
     --trackfile file     Override the trackfile name

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ you can add a [bash alias](https://wiki.archlinux.org/index.php/Bash#Aliases)
 to your ~/.bashrc file. Here `alias isbg="/path/to/isbg.py"` should do the
 trick.
 
+If the script does not start claiming absence of docopt Python module (not
+shipped in older OSes, nor in even new Solaris/illumos distributions), you
+can fetch [a version of docopt backported for Python 2.4+ compatibility](https://github.com/davidhalter-archive/xen_backup/blob/master/docopt.py)
+and place it in the same directory as your isbg workspace, or copy into the
+system Python module directory like "/usr/lib/python-2.x/".
+
 ## Install in Debian<a name="Install-in-Debian"></a>
 
 There is a package in mentor.debian.net pending approval from the community.

--- a/isbg.py
+++ b/isbg.py
@@ -61,6 +61,7 @@ Options:
     --teachonly          Don't search spam, just learn from folders
     --trackfile file     Override the trackfile name
     --verbose            Show IMAP stuff happening
+    --verbose-sa         Show SpamAssassin stuff happening
     --version            Show the version information
 
     (Your inbox will remain untouched unless you specify --flag or --delete)
@@ -251,6 +252,23 @@ if opts["--spamc"] is True:
     spamc = True
     satest = ["spamc", "-c"]
     sasave = ["spamc"]
+    if opts["--verbose-sa"] is True:
+        satest.append("-R")
+        satest.append("-l")
+        sasave.append("-R")
+        sasave.append("-l")
+else:
+    if opts["--verbose-sa"] is True:
+        satest.append("--debug")
+        satest.append("--progress")
+        sasave.append("--debug")
+        sasave.append("--progress")
+
+if opts["--verbose-sa"] is True:
+    spamc_learn_spam.append("-R")
+    spamc_learn_spam.append("-l")
+    spamc_learn_ham.append("-R")
+    spamc_learn_ham.append("-l")
 
 if opts["--spaminbox"] is not None:
     spaminbox = opts["--spaminbox"]

--- a/isbg.py
+++ b/isbg.py
@@ -90,7 +90,7 @@ try:
 except ImportError:
     from md5 import md5
 
-
+imap = None
 imapuser = ''
 imapproxyuser = None
 imaphost = 'localhost'
@@ -144,6 +144,13 @@ partialrun = None
 
 
 def errorexit(msg, exitcode=exitcodeflags):
+    try:
+        global imap
+        if imap is not None:
+            imap.logout()
+            imap = None
+    except:
+        pass
     sys.stderr.write(msg)
     sys.stderr.write("\nUse --help to see valid options and arguments\n")
     sys.exit(exitcode)
@@ -725,7 +732,7 @@ if opts["--teachonly"] is False:
 
 # sign off
 imap.logout()
-del imap
+imap = None
 
 
 if opts["--nostats"] is False:

--- a/isbg.py
+++ b/isbg.py
@@ -105,6 +105,9 @@ alreadylearnt = "Message was already un/learned"
 satest = ["spamassassin", "--exit-code"]
 # sasave is the one that dumps out a munged message including report
 sasave = ["spamassassin"]
+# SpamAssassin Client used with the --spam option
+spamc_learn_ham = ["spamc", "--learntype=ham"]
+spamc_learn_spam = ["spamc", "--learntype=spam"]
 # what we use to set flags on the original spam in imapbox
 spamflagscmd = "+FLAGS.SILENT"
 # and the flags we set them to (none by default)
@@ -462,8 +465,12 @@ if opts["--learnspambox"] is not None:
     uids = uids[0].split()
     for u in uids:
         body = getmessage(u)
-        p = Popen(["spamc", "--learntype=spam"],
-                  stdin=PIPE, stdout=PIPE, close_fds=True)
+        if opts["--verbose"] is True:
+            print("Starting spamc program : %s ..." % spamc_learn_spam)
+        try:
+            p = Popen(spamc_learn_spam, stdin=PIPE, stdout=PIPE, close_fds=True)
+        except Exception, e:
+            errorexit("Running external program %s failed - %s" % (spamc_learn_spam, str(e)))
         try:
             out = p.communicate(body)[0]
         except:
@@ -497,8 +504,12 @@ if opts["--learnhambox"] is not None:
     uids = uids[0].split()
     for u in uids:
         body = getmessage(u)
-        p = Popen(["spamc", "--learntype=ham"],
-                  stdin=PIPE, stdout=PIPE, close_fds=True)
+        if opts["--verbose"] is True:
+            print("Starting spamc program : %s ..." % spamc_learn_ham)
+        try:
+            p = Popen(spamc_learn_ham, stdin=PIPE, stdout=PIPE, close_fds=True)
+        except Exception, e:
+            errorexit("Running external program %s failed - %s" % (spamc_learn_ham, str(e)))
         try:
             out = p.communicate(body)[0]
         except:
@@ -566,7 +577,12 @@ for u in uids:
     body = getmessage(u, pastuids)
 
     # Feed it to SpamAssassin in test mode
-    p = Popen(satest, stdin=PIPE, stdout=PIPE, close_fds=True)
+    if opts["--verbose"] is True:
+        print("Starting spamassassin test program : %s ..." % satest)
+    try:
+        p = Popen(satest, stdin=PIPE, stdout=PIPE, close_fds=True)
+    except Exception, e:
+        errorexit("Running external program %s failed - %s" % (satest, str(e)))
     try:
         score = p.communicate(body)[0]
         if opts["--spamc"] is False:
@@ -598,7 +614,12 @@ for u in uids:
         # do we want to include the spam report
         if noreport is False:
             # filter it through sa
-            p = Popen(sasave, stdin=PIPE, stdout=PIPE, close_fds=True)
+            if opts["--verbose"] is True:
+                print("Starting spamassassin report save program : %s ..." % sasave)
+            try:
+                p = Popen(sasave, stdin=PIPE, stdout=PIPE, close_fds=True)
+            except Exception, e:
+                errorexit("Running external program %s failed - %s" % (sasave, str(e)))
             try:
                 body = p.communicate(body)[0]
             except:

--- a/isbg.py
+++ b/isbg.py
@@ -454,7 +454,7 @@ if opts["--imaplist"] is True:
 if opts["--learnspambox"] is not None:
     if opts["--verbose"] is True:
         print("Teach SPAM to SA from:", learnspambox)
-    res = imap.select(learnspambox, 0)
+    res = imap.select(learnspambox, readonly=False)
     assertok(res, 'select', learnspambox)
     s_tolearn = int(res[1][0])
     s_learnt = 0
@@ -489,7 +489,7 @@ if opts["--learnspambox"] is not None:
 if opts["--learnhambox"] is not None:
     if opts["--verbose"] is True:
         print("Teach HAM to SA from:", learnhambox)
-    res = imap.select(learnhambox, 0)
+    res = imap.select(learnhambox, readonly=False)
     assertok(res, 'select', learnhambox)
     h_tolearn = int(res[1][0])
     h_learnt = 0
@@ -523,11 +523,11 @@ uids = []
 
 if opts["--teachonly"] is False:
     # check spaminbox exists by examining it
-    res = imap.select(spaminbox, 1)
+    res = imap.select(spaminbox, readonly=True)
     assertok(res, 'select', spaminbox, 1)
 
     # select inbox
-    res = imap.select(imapinbox, 1)
+    res = imap.select(imapinbox, readonly=True)
     assertok(res, 'select', imapinbox, 1)
 
     # get the uids of all mails with a size less then the maxsize

--- a/isbg.py
+++ b/isbg.py
@@ -299,7 +299,7 @@ if opts["--imapport"] is None:
         imapport = 993
 
 if pastuidsfile is None:
-    pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track")
+    pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track" + "%" + imapuser + "%" + imapproxyuser)
     m = md5()
     m.update(imaphost)
     m.update(imapuser)
@@ -308,8 +308,7 @@ if pastuidsfile is None:
     pastuidsfile = pastuidsfile + res
 
 if opts["--lockfilename"] is None:
-    lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock")
-
+    lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock" + "%" + imapuser + "%" + imapproxyuser)
 
 # Delete lock file
 def removelock():

--- a/isbg.py
+++ b/isbg.py
@@ -31,6 +31,13 @@ Options:
     --imappasswd passwd  IMAP account password
     --imapport port      Use a custom port
     --imapuser username  Who you login as
+    --imapproxyuser userbox     Use proxyauth on IMAP host. If set, allows
+                         the sysadmin or a secretary (identified by username
+                         and passwd above) to log into the IMAP server and
+                         administer the userbox account specified here.
+                         Otherwise the username accesses his or her own box.
+                         Required by Sun/iPlanet/Netscape IMAP servers to
+                         be able to use an administrative user.
     --imapinbox mbox     Name of your inbox folder
     --learnspambox mbox  Name of your learn spam folder
     --learnhambox mbox   Name of your learn ham folder
@@ -83,6 +90,7 @@ except ImportError:
 
 
 imapuser = ''
+imapproxyuser = None
 imaphost = 'localhost'
 imappasswd = None
 imapinbox = "INBOX"
@@ -201,6 +209,9 @@ if opts["--imapport"] is not None:
 
 if opts["--imapuser"] is not None:
     imapuser = opts["--imapuser"]
+
+if opts["--imapproxyuser"] is not None:
+    imapproxyuser = opts["--imapproxyuser"]
 
 if opts["--imapinbox"] is not None:
     imapinbox = opts["--imapinbox"]
@@ -426,6 +437,12 @@ else:
 # Authenticate (only simple supported)
 res = imap.login(imapuser, imappasswd)
 assertok(res, "login", imapuser, 'xxxxxxxx')
+
+if opts["--imapproxyuser"] is not None:
+    if opts["--verbose"] is True:
+        print("Logged in as %s, now setting proxyauth to administer mailbox of %s" % (imapuser, imapproxyuser))
+    res = imap.proxyauth(imapproxyuser)
+    assertok(res, "proxyauth", imapproxyuser, 'xxxxxxxx')
 
 # List imap directories
 if opts["--imaplist"] is True:

--- a/isbg.py
+++ b/isbg.py
@@ -6,7 +6,7 @@ isbg scans an IMAP Inbox and runs every entry against SpamAssassin.
 For any entries that match, the message is copied to another folder,
 and the original marked or deleted.
 
-This software was mainly written Roger Binns <rogerb@rogerbinns.com>
+This software was mainly written by Roger Binns <rogerb@rogerbinns.com>
 and maintained by Thomas Lecavelier <thomas@lecavelier.name> since
 novembre 2009. You may use isbg under any OSI approved open source
 license such as those listed at http://opensource.org/licenses/alphabetical
@@ -59,12 +59,12 @@ Options:
 
 """
 
-import sys  # Because sys.stderr.write() is called bellow
+import sys  # Because sys.stderr.write() is called below
 
 try:
     from docopt import docopt  # Creating command-line interface
 except ImportError:
-    sys.stderr.write("Missing dependency: docopt")
+    sys.stderr.write("Missing dependency: docopt\n")
 
 from subprocess import Popen, PIPE
 


### PR DESCRIPTION
Proxyauth verified against a Sun Messaging server : 
````
 ./isbg.py --imapuser mailadmin --imappasswd Adm1nPaSs --imapproxyuser enduser@domain.com --imaplist --imaphost imap.domain.com

  "/" INBOX', '  "/" Drafts', '  "/" Junk', '  "/" Sent', '  "/" trusted'])

('select', 'INBOX.spam', 1) returned ('NO', ['Mailbox does not exist']) - aborting

Use --help to see valid options and arguments
````

Some more improvements piled on as I was beginning to actually use the script ;)