### PR TITLE
isbg.py : fix lock/pastuid file patterns when "imapproxyuser is None"

### DIFF
--- a/isbg.py
+++ b/isbg.py
@@ -300,13 +300,14 @@ if opts["--imapport"] is None:
         imapport = 993
 
 if pastuidsfile is None:
-    if imapproxyuser is None:
-        pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track" + "%" + imapuser)
-    else:
-        pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track" + "%" + imapuser + "%" + imapproxyuser)
+    pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track")
     m = md5()
     m.update(imaphost)
     m.update(imapuser)
+    if imapproxyuser is None:
+        m.update('')
+    else:
+        m.update(imapproxyuser)
     m.update(repr(imapport))
     res = hexof(m.digest())
     pastuidsfile = pastuidsfile + res
@@ -349,6 +350,10 @@ if passwdfilename is None:
     m = md5()
     m.update(imaphost)
     m.update(imapuser)
+    if imapproxyuser is None:
+        m.update('')
+    else:
+        m.update(imapproxyuser)
     m.update(repr(imapport))
     passwdfilename = os.path.expanduser("~" + os.sep +
                                         ".isbg-" + hexof(m.digest()))
@@ -359,6 +364,11 @@ if passwordhash is None:
     m.update(imaphost)
     m.update(m.digest())
     m.update(imapuser)
+    m.update(m.digest())
+    if imapproxyuser is None:
+        m.update('')
+    else:
+        m.update(imapproxyuser)
     m.update(m.digest())
     m.update(repr(imapport))
     m.update(m.digest())

--- a/isbg.py
+++ b/isbg.py
@@ -300,7 +300,10 @@ if opts["--imapport"] is None:
         imapport = 993
 
 if pastuidsfile is None:
-    pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track")
+    if imapproxyuser is None:
+        pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track" + "%" + imapuser)
+    else:
+        pastuidsfile = os.path.expanduser("~" + os.sep + ".isbg-track" + "%" + imapuser + "%" + imapproxyuser)
     m = md5()
     m.update(imaphost)
     m.update(imapuser)
@@ -309,8 +312,10 @@ if pastuidsfile is None:
     pastuidsfile = pastuidsfile + res
 
 if opts["--lockfilename"] is None:
-    lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock")
-
+    if imapproxyuser is None:
+        lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock" + "%" + imapuser)
+    else:
+        lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock" + "%" + imapuser + "%" + imapproxyuser)
 
 # Delete lock file
 def removelock():

--- a/isbg.py
+++ b/isbg.py
@@ -304,9 +304,7 @@ if pastuidsfile is None:
     m = md5()
     m.update(imaphost)
     m.update(imapuser)
-    if imapproxyuser is None:
-        m.update('')
-    else:
+    if imapproxyuser is not None:
         m.update(imapproxyuser)
     m.update(repr(imapport))
     res = hexof(m.digest())
@@ -314,7 +312,8 @@ if pastuidsfile is None:
 
 if opts["--lockfilename"] is None:
     if imapproxyuser is None:
-        lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock" + "%" + imapuser)
+        # This was the name in pre-imapproxyuser versions, single-session only
+        lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock")
     else:
         lockfilename = os.path.expanduser("~" + os.sep + ".isbg-lock" + "%" + imapuser + "%" + imapproxyuser)
 
@@ -350,9 +349,7 @@ if passwdfilename is None:
     m = md5()
     m.update(imaphost)
     m.update(imapuser)
-    if imapproxyuser is None:
-        m.update('')
-    else:
+    if imapproxyuser is not None:
         m.update(imapproxyuser)
     m.update(repr(imapport))
     passwdfilename = os.path.expanduser("~" + os.sep +
@@ -365,11 +362,9 @@ if passwordhash is None:
     m.update(m.digest())
     m.update(imapuser)
     m.update(m.digest())
-    if imapproxyuser is None:
-        m.update('')
-    else:
+    if imapproxyuser is not None:
         m.update(imapproxyuser)
-    m.update(m.digest())
+        m.update(m.digest())
     m.update(repr(imapport))
     m.update(m.digest())
     passwordhash = m.digest()


### PR DESCRIPTION
Follow-up on PR #60

This should address at least part of issue #68 that relates to non-proxied mode of operation vs. single user only (I did not yet grasp the 16-byte ID suggestion).