### PR TITLE
Fix typo in isbg reference

### DIFF
--- a/isbg/isbg.py
+++ b/isbg/isbg.py
@@ -876,7 +876,7 @@ def isbg_run():
     isbg.parse_args()
     ch = logging.StreamHandler()
     isbg.logger.addHandler(ch)
-    if self.verbose:
+    if isbg.verbose:
         ch.setLevel(logging.DEBUG)
     else:
         ch.setLevel(logging.INFO)


### PR DESCRIPTION
Typo induced during refactoring leads to directly calling isbg not working.