### PR TITLE
Fix imap reference typo

### DIFF
--- a/isbg/isbg.py
+++ b/isbg/isbg.py
@@ -726,10 +726,10 @@ class ISBG:
                                 res = self.imap.uid("STORE", u, self.spamflagscmd, "(\\Deleted)")
                                 self.assertok(res, "uid store", u, self.spamflagscmd, "(\\Deleted)")
                         elif learntype['moveto'] is not None:
-                            res = imap.uid("COPY", u, learntype['moveto'])
+                            res = self.imap.uid("COPY", u, learntype['moveto'])
                             self.assertok(res, "uid copy", u, learntype['moveto'])
                         elif self.learnthenflag:
-                            res = imap.uid("STORE", u, self.spamflagscmd, "(\\Flagged)")
+                            res = self.imap.uid("STORE", u, self.spamflagscmd, "(\\Flagged)")
                             self.assertok(res, "uid store", u, self.spamflagscmd, "(\\Flagged)")
                 self.pastuid_write(uidvalidity, origpastuids, newpastuids, folder=learntype['learntype'])
             result.append((n_tolearn, n_learnt))


### PR DESCRIPTION
27731f6 is needed to fix a typo. Not sure if 041ef82 should be included.

We should maybe think about making isbg more modular and add callbacks or something so users can directly specify mail filtering and actions using code instead of adding an ever-expanding plethora of flags.

The main isbg script would then essentially be a demo of that API.