### PR TITLE
avoid that spamassassin is executed twice for one spam mail

### DIFF
--- a/isbg/__init__.py
+++ b/isbg/__init__.py
@@ -14,8 +14,8 @@ from __future__ import unicode_literals
 
 
 from .isbg import ISBG, ISBGError, __version__, __exitcodes__, __license__
-from .spamproc import learn_mail, test_mail, feed_mail
+from .spamproc import learn_mail, test_mail
 from .sa_unwrap import unwrap
 
 __all__ = ["__version__", "__exitcodes__", "__license__", "learn_mail",
-           "test_mail", "feed_mail", "unwrap", "ISBG", "ISBGError"]
+           "test_mail", "unwrap", "ISBG", "ISBGError"]

--- a/isbg/spamproc.py
+++ b/isbg/spamproc.py
@@ -92,8 +92,13 @@ def learn_mail(mail, learn_type):
     return code, orig_code
 
 
-def exec_spamassassin(mail, spamc=False, cmd=False):
-    """Call local spamassassin."""
+def test_mail(mail, spamc=False, cmd=False):
+    """Test a email with spamassassin."""
+    score = "0/0\n"
+    orig_code = None
+    spamassassin_result = None
+    returncode = None
+
     if cmd:
         satest = cmd
     elif spamc:
@@ -103,29 +108,17 @@ def exec_spamassassin(mail, spamc=False, cmd=False):
 
     proc = utils.popen(satest)
 
-    spamassassin_result = proc.communicate(imaputils.mail_content(mail)
-                                           )[0].decode(errors='ignore')
-    returncode = proc.returncode
-
-    proc.stdin.close()
-
-    return spamassassin_result, returncode
-
-
-def test_mail(mail, spamc=False, cmd=False):
-    """Test a email with spamassassin."""
-    score = "0/0\n"
-    orig_code = None
-
     try:
-        spamassassin_result, returncode = exec_spamassassin(mail, spamc, cmd)
+        spamassassin_result = proc.communicate(imaputils.mail_content(mail)
+                                               )[0].decode(errors='ignore')
+        returncode = proc.returncode
+        proc.stdin.close()
         score = utils.score_from_mail(spamassassin_result)
-        orig_code = returncode
 
     except Exception:  # pylint: disable=broad-except
         score = "-9999"
 
-    return score, orig_code, spamassassin_result
+    return score, returncode, spamassassin_result
 
 
 class Sa_Learn(object):

--- a/tests/test_spamproc.py
+++ b/tests/test_spamproc.py
@@ -88,11 +88,11 @@ def test_test_mail():
 
     if cmd_exists('spamc'):
         # We test the mail with spamc:
-        score1, code1 = spamproc.test_mail(mail, True)
-        score2, code2 = spamproc.test_mail(mail, cmd=["spamc", "-c"])
+        score1, code1, spamassassin_result = spamproc.test_mail(mail, True)
+        score2, code2, spamassassin_result = spamproc.test_mail(mail, cmd=["spamc", "-E"])
         assert score1 == score2, "The score should be the same."
         assert code1 == code2, "The return code should be the same."
-        score, code = spamproc.test_mail("", True)
+        score, code, spamassassin_result = spamproc.test_mail("", True)
         assert score == u'-9999', 'It should return a error'
         assert code is None, 'It should return a error'
     else:
@@ -101,16 +101,16 @@ def test_test_mail():
             spamproc.test_mail(mail, True)
         with pytest.raises(OSError, match="No such file",
                            message="Should rise OSError."):
-            spamproc.test_mail(mail, cmd=["spamc", "-c"])
+            spamproc.test_mail(mail, cmd=["spamc", "-E"])
 
     if cmd_exists('spamassassin'):
         # We test the mail with spamassassin:
-        score3, code3 = spamproc.test_mail(mail, False)
-        score4, code4 = spamproc.test_mail(mail, cmd=["spamassassin",
+        score3, code3, spamassassin_result = spamproc.test_mail(mail, False)
+        score4, code4, spamassassin_result = spamproc.test_mail(mail, cmd=["spamassassin",
                                                       "--exit-code"])
         assert score3 == score4, "The score should be the same."
         assert code3 == code4, "The return code should be the same."
-        score, code = spamproc.test_mail("", False)
+        score, code, spamassassin_result = spamproc.test_mail("", False)
         assert score == u'-9999', 'It should return a error'
         assert code is None, 'It should return a error'
     else:
@@ -122,60 +122,12 @@ def test_test_mail():
             spamproc.test_mail(mail, cmd=["spamassassin", "--exit-code"])
 
     # We try a random cmds (existant and unexistant):
-    score, code = spamproc.test_mail("", cmd=["echo"])
+    score, code, spamassassin_result = spamproc.test_mail("", cmd=["echo"])
     assert score == u'-9999', 'It should return a error'
     assert code is None, 'It should return a error'
     with pytest.raises(OSError, match="No such file",
                        message="Should rise OSError."):
         spamproc.test_mail(mail, cmd=["_____fooo___x_x"])
-
-
-def test_feed_mail():
-    """Test feed_mail."""
-    fmail = open('examples/spam.eml', 'rb')
-    ftext = fmail.read()
-    mail = new_message(ftext)
-    fmail.close()
-
-    if cmd_exists('spamc'):
-        # We test the mail with spamc:
-        new_mail1, code1 = spamproc.feed_mail(mail, True)
-        new_mail2, code2 = spamproc.feed_mail(mail, cmd=["spamc"])
-        assert code1 == code2, "The return code should be the same."
-        new_mail, code = spamproc.feed_mail("", True)
-        assert new_mail == '-9999', 'It should return a error'
-        assert code is None, 'It should return a error'
-    else:
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
-            spamproc.feed_mail(mail, True)
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
-            spamproc.feed_mail(mail, cmd=["spamc"])
-
-    if cmd_exists('spamassassin'):
-        # We test the mail with spamassassin:
-        new_mail3, code3 = spamproc.feed_mail(mail, False)
-        new_mail4, code4 = spamproc.test_mail(mail, cmd=["spamassassin"])
-        assert code3 == code4, "The return code should be the same."
-        new_mail, code = spamproc.test_mail("", False)
-        assert new_mail == u'-9999', 'It should return a error'
-        assert code is None, 'It should return a error'
-    else:
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
-            spamproc.feed_mail(mail, False)
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
-            spamproc.feed_mail(mail, cmd=["spamassassin"])
-
-    # We try a random cmds (existant and unexistant
-    new_mail, code = spamproc.feed_mail("", cmd=["echo"])
-    assert new_mail == u'-9999', 'It should return a error'
-    assert code is None, 'It should return a error'
-    with pytest.raises(OSError, match="No such file",
-                       message="Should rise OSError."):
-        spamproc.feed_mail(mail, cmd=["_____fooo___x_x"])
 
 
 class Test_Sa_Learn(object):
@@ -244,7 +196,7 @@ class Test_SpamAssassin(object):
         sa = spamproc.SpamAssassin()
         assert sa.cmd_test == ["spamassassin", "--exit-code"]
         sa.spamc = True
-        assert sa.cmd_test == ["spamc", "-c"]
+        assert sa.cmd_test == ["spamc", "-E"]
         sa.spamc = False
         assert sa.cmd_test == ["spamassassin", "--exit-code"]
 
@@ -305,11 +257,11 @@ class Test_SpamAssassin(object):
         # OSError required when it's run without spamassassin (travis-cl)
         with pytest.raises((AttributeError, OSError, MessageError),
                            message="Should rise error, IMAP not created."):
-            sa._process_spam(1, u"3/10\n", "", [])
+            sa._process_spam(1, u"3/10\n", "", [], 0, "")
 
         sa.noreport = True
         sa.deletehigherthan = 2
-        sa._process_spam(1, u"3/10\n", "", [])
+        sa._process_spam(1, u"3/10\n", "", [], 0, "")
 
     def test_process_inbox(self):
         """Test process_inbox."""


### PR DESCRIPTION
In spamproc.py each mail was first processed by test_mail() function. test_mail() is returning if the mail is SPAM or no SPAM.
If the mail has been classified as SPAM feed_mail() is executed to attach the SPAM report to the mail. But feed_mail() will execute spamassassin again for the same email.

Due to the high ressource usage of spamassassin that's not very efficient. Now spamassassin will only called once.