### PR TITLE
let spamc process mails larger than 500 KB (fix #117)

### DIFF
--- a/isbg/spamproc.py
+++ b/isbg/spamproc.py
@@ -102,7 +102,8 @@ def test_mail(mail, spamc=False, cmd=False):
     if cmd:
         satest = cmd
     elif spamc:
-        satest = ["spamc", "-E"]
+        # let spamc process mails larger than 500 KB if ISBG forwards them
+        satest = ["spamc", "-E", "--max-size=268435450"]
     else:
         satest = ["spamassassin", "--exit-code"]
 
@@ -199,7 +200,7 @@ class SpamAssassin(object):
     def cmd_test(self):
         """Is the command to use to test if the message is spam."""
         if self.spamc:  # pylint: disable=no-member
-            return ["spamc", "-E"]
+            return ["spamc", "-E", "--max-size=268435450"]
         return ["spamassassin", "--exit-code"]
 
     @classmethod

--- a/tests/test_spamproc.py
+++ b/tests/test_spamproc.py
@@ -89,7 +89,8 @@ def test_test_mail():
     if cmd_exists('spamc'):
         # We test the mail with spamc:
         score1, code1, spamassassin_result = spamproc.test_mail(mail, True)
-        score2, code2, spamassassin_result = spamproc.test_mail(mail, cmd=["spamc", "-E"])
+        score2, code2, spamassassin_result = spamproc.test_mail(mail, cmd=["spamc",
+                                                     "-E", "--max-size=268435450"])
         assert score1 == score2, "The score should be the same."
         assert code1 == code2, "The return code should be the same."
         score, code, spamassassin_result = spamproc.test_mail("", True)
@@ -101,7 +102,7 @@ def test_test_mail():
             spamproc.test_mail(mail, True)
         with pytest.raises(OSError, match="No such file",
                            message="Should rise OSError."):
-            spamproc.test_mail(mail, cmd=["spamc", "-E"])
+            spamproc.test_mail(mail, cmd=["spamc", "-E", "--max-size=268435450"])
 
     if cmd_exists('spamassassin'):
         # We test the mail with spamassassin:
@@ -196,7 +197,7 @@ class Test_SpamAssassin(object):
         sa = spamproc.SpamAssassin()
         assert sa.cmd_test == ["spamassassin", "--exit-code"]
         sa.spamc = True
-        assert sa.cmd_test == ["spamc", "-E"]
+        assert sa.cmd_test == ["spamc", "-E", "--max-size=268435450"]
         sa.spamc = False
         assert sa.cmd_test == ["spamassassin", "--exit-code"]
 


### PR DESCRIPTION
By default, `spamc` won't process messages larger than 500KB, even though ISBG already filters message size with`maxsize`.

The result is that if you specify a `maxsize` greater than 500KB, you get that kind of error on large messages:

```
['spamc', '-E'] error for mail 715
NoneType: None
<email.message.Message object at 0x7f6b87a12048>
```

This PR fixes this by letting `spamc` process messages up to 256MB (the maximum size). That way, ISBG is the only thing filtering based on message size.