### PR TITLE
Enable python3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ env:
   global:
 
 language: python
+dist: xenial
 
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 # Pypy version:
   - "pypy3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.6"
   - "3.7"
 # Pypy version:
-  - "pypy3"
+  - "pypy3.5"
 
 before_script:
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -72,9 +72,9 @@ def test_parse_args():
     for op in ["--foo"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="[options]",
-                       message="It should rise a docopt SystemExit"):
+    with pytest.raises(isbg.ISBGError, match="[options]"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a docopt SystemExit")
 
     # Parse with bogus deletehigherthan
     del sys.argv[1:]
@@ -83,9 +83,9 @@ def test_parse_args():
                "0"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="too small",
-                       message="It should rise a too small ISBGError"):
+    with pytest.raises(isbg.ISBGError, match="too small"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a too small ISBGError")
 
     del sys.argv[1:]
     for op in ["--imaphost", "localhost", "--imapuser", "anonymous",
@@ -93,10 +93,9 @@ def test_parse_args():
                "foo"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="Unrecognized score",
-                       message=("It should rise a unrecognized score" +
-                                "ISBGError")):
+    with pytest.raises(isbg.ISBGError, match="Unrecognized score"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a unrecognized score" + "ISBGError")
 
     # Parse with ok deletehigherthan
     del sys.argv[1:]
@@ -114,19 +113,18 @@ def test_parse_args():
                "--imappasswd", "none", "--dryrun", "--maxsize", "0"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="too small",
-                       message="It should rise a too small ISBGError"):
+    with pytest.raises(isbg.ISBGError, match="too small"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a too small ISBGError")
 
     del sys.argv[1:]
     for op in ["--imaphost", "localhost", "--imapuser", "anonymous",
                "--imappasswd", "none", "--dryrun", "--maxsize", "foo"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="Unrecognised size",
-                       message=("It should rise a Unrecognised size" +
-                                "ISBGError")):
+    with pytest.raises(isbg.ISBGError, match="Unrecognised size"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a Unrecognised size" + "ISBGError")
 
     # Parse with ok maxsize
     del sys.argv[1:]
@@ -143,10 +141,9 @@ def test_parse_args():
                "--imappasswd", "none", "--dryrun", "--partialrun", "-10"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="equal to 0 or higher",
-                       message=("It should rise a equal to 0 or higher " +
-                                "ISBGError")):
+    with pytest.raises(isbg.ISBGError, match="equal to 0 or higher"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a equal to 0 or higher " + "ISBGError")
 
     # Parse with 0 partialrun
     del sys.argv[1:]
@@ -162,10 +159,9 @@ def test_parse_args():
                "--imappasswd", "none", "--dryrun", "--partialrun", "foo"]:
         sys.argv.append(op)
     sbg = isbg.ISBG()
-    with pytest.raises(isbg.ISBGError, match="must be a integer",
-                       message=("It should rise a invalid literal " +
-                                "ValueError")):
+    with pytest.raises(isbg.ISBGError, match="must be a integer"):
         __main__.parse_args(sbg)
+        pytest.fail("It should rise a invalid literal " + "ValueError")
 
     # Parse with ok partialrun and verbose and nossl
     del sys.argv[1:]
@@ -190,35 +186,34 @@ def test_main():
     sys.argv.append("--ignorelockfile")
 
     with mock.patch.object(isbg, "__name__", "__main__"):
-        with pytest.raises(SystemExit, match="10",
-                           message="Not error or unexpected error"):
+        with pytest.raises(SystemExit, match="10"):
             __main__.main()
+            pytest.fail("Not error or unexpected error")
 
-    with pytest.raises(SystemExit, match="10",
-                       message="Not error or unexpected error"):
-        with pytest.raises(isbg.ISBGError,
-                           match="10",
-                           message="Not error or unexpected error message"):
+    with pytest.raises(SystemExit, match="10"):
+        with pytest.raises(isbg.ISBGError, match="10"):
             __main__.main()
+            pytest.fail("Not error or unexpected error message")
+        pytest.fail("Not error or unexpected error")
 
     sys.argv.append("--version")
     with mock.patch.object(isbg, "__name__", "__main__"):
-        with pytest.raises(SystemExit,
-                           message="Not error or unexpected error"):
+        with pytest.raises(SystemExit):
             __main__.main()
+            pytest.fail("Not error or unexpected error")
 
     sys.argv.append("--exitcodes")
     with mock.patch.object(isbg, "__name__", "__main__"):
-        with pytest.raises(SystemExit,
-                           message="Not error or unexpected error"):
+        with pytest.raises(SystemExit):
             __main__.main()
+            pytest.fail("Not error or unexpected error")
 
     del sys.argv[1:]
     sys.argv.append("--usage")
     with mock.patch.object(isbg, "__name__", "__main__"):
-        with pytest.raises(SystemExit,
-                           message="Not Exit or unexpected error"):
+        with pytest.raises(SystemExit):
             __main__.main()
+            pytest.fail("Not Exit or unexpected error")
 
     # Restore pytest options:
     sys.argv = args[:]

--- a/tests/test_imaputils.py
+++ b/tests/test_imaputils.py
@@ -91,17 +91,6 @@ def test_imapflags():
     assert imaputils.imapflags(['foo', 'boo']) == '(foo,boo)'
 
 
-class TestIsbgImap4(object):
-    """Test IsbgImap4."""
-
-    def test(self):
-        """Test the object."""
-        with pytest.raises(gaierror, match="[Errno -5]"):
-            imaputils.IsbgImap4()
-            pytest.fail("No address associated with hostname")
-        # FIXME: require network
-
-
 def test_login_imap():
     """Test login_imap."""
     with pytest.raises(TypeError, match="ImapSettings"):

--- a/tests/test_imaputils.py
+++ b/tests/test_imaputils.py
@@ -47,9 +47,9 @@ from isbg import imaputils  # noqa: E402
 
 def test_mail_content():
     """Test mail_content function."""
-    with pytest.raises(email.errors.MessageError,
-                       message="mail 'None' is not a email.message.Message."):
+    with pytest.raises(email.errors.MessageError):
         imaputils.mail_content(None)
+        pytest.fail("mail 'None' is not a email.message.Message.")
     fmail = open('examples/spam.from.spamassassin.eml', 'rb')
     ftext = fmail.read()
     mail = imaputils.new_message(ftext)
@@ -96,24 +96,24 @@ class TestIsbgImap4(object):
 
     def test(self):
         """Test the object."""
-        with pytest.raises(gaierror, match="[Errno -5]",
-                           message="No address associated with hostname"):
+        with pytest.raises(gaierror, match="[Errno -5]"):
             imaputils.IsbgImap4()
+            pytest.fail("No address associated with hostname")
         # FIXME: require network
 
 
 def test_login_imap():
     """Test login_imap."""
-    with pytest.raises(TypeError, match="ImapSettings",
-                       message="spected a ImapSettings"):
+    with pytest.raises(TypeError, match="ImapSettings"):
         imaputils.login_imap(None)
+        pytest.fail("spected a ImapSettings")
 
     imapsets = imaputils.ImapSettings()
     imapsets.host = ''  # don't try to connect to internet
     imapsets.nossl = True
-    with pytest.raises(Exception, match="[Errno -5]",
-                       message="No address associated with hostname"):
+    with pytest.raises(Exception, match="[Errno -5]"):
         imaputils.login_imap(imapsets, logger=logging.getLogger(__name__))
+        pytest.fail("No address associated with hostname")
     # FIXME: require network
 
 

--- a/tests/test_isbg.py
+++ b/tests/test_isbg.py
@@ -82,7 +82,6 @@ class TestISBG(object):
     def test_do_isbg(self):
         """Test do_isbg."""
         sbg = isbg.ISBG()
-        with pytest.raises(isbg.ISBGError, match="specify your imap password",
-                           message=("It should rise a specify imap password " +
-                                    "ISBGError")):
+        with pytest.raises(isbg.ISBGError, match="specify your imap password"):
             sbg.do_isbg()
+            pytest.fail("It should rise a specify imap password " + "ISBGError")

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -121,9 +121,9 @@ NTk2YTEyMDIyYTM4ZDc3YjM3Mzk2OGNlMzc1Yg==
         # Test with a erroneous filename.
         sec = secrets.SecretIsbg(filename="", imapset=imapset)
         assert sec.get("foo") is None
-        with pytest.raises(EnvironmentError, match="\[Errno ",
-                           message="A EnvironmentError should be raised."):
+        with pytest.raises(EnvironmentError, match="\[Errno "):
             sec.set("foo", "boo")
+            pytest.fail("A EnvironmentError should be raised.")
 
         # Test with a ok filename:
         sec = secrets.SecretIsbg(filename="tmp.txt", imapset=imapset)
@@ -134,15 +134,15 @@ NTk2YTEyMDIyYTM4ZDc3YjM3Mzk2OGNlMzc1Yg==
         sec.set("foo3", "boo4")
         assert sec.get("foo3") == "boo4"
 
-        with pytest.raises(ValueError, match="Key 'foo3' exists.",
-                           message="It should raise a ValueError"):
+        with pytest.raises(ValueError, match="Key 'foo3' exists."):
             sec.set("foo3", "boo5", overwrite=False)
+            pytest.fail("It should raise a ValueError")
 
         assert sec.get("foo3") == "boo4"
 
-        with pytest.raises(TypeError,
-                           message="A TypeError should be raised."):
+        with pytest.raises(TypeError):
             sec.set("foo4", 4)
+            pytest.fail("A TypeError should be raised.")
         assert sec.get("foo2") == "boo2"
 
         # Remove the created keys:
@@ -152,21 +152,21 @@ NTk2YTEyMDIyYTM4ZDc3YjM3Mzk2OGNlMzc1Yg==
         assert sec.get("foo2") is None
 
         # Remove non existant key:
-        with pytest.raises(ValueError, match="Key 'foo4' not",
-                           message="It should raise a ValueError"):
+        with pytest.raises(ValueError, match="Key 'foo4' not"):
             sec.delete("foo4")
+            pytest.fail("It should raise a ValueError")
 
         # Remove last key, it should delete the file:
         sec.delete("foo3")
         assert sec.get("foo3") is None
-        with pytest.raises(EnvironmentError, match="\[Errno 2\]",
-                           message="A EnvironmentError should be raised."):
+        with pytest.raises(EnvironmentError, match="\[Errno 2\]"):
             os.remove("tmp.txt")
+            pytest.fail("A EnvironmentError should be raised.")
 
         # Remove non existant key in non existant file:
-        with pytest.raises(ValueError, match="Key 'foo4' not",
-                           message="It should raise a ValueError"):
+        with pytest.raises(ValueError, match="Key 'foo4' not"):
             sec.delete("foo4")
+            pytest.fail("It should raise a ValueError")
 
 
 class Test_SecretKeyring(object):
@@ -185,9 +185,9 @@ class Test_SecretKeyring(object):
         sec.set("foo3", "boo4")
         assert sec.get("foo3") == "boo4"
 
-        with pytest.raises(ValueError, match="Key 'foo3' exists.",
-                           message="It should raise a ValueError"):
+        with pytest.raises(ValueError, match="Key 'foo3' exists."):
             sec.set("foo3", "boo5", overwrite=False)
+            pytest.fail("It should raise a ValueError")
 
         # Remove the created keys:
         sec.delete("foo1")
@@ -196,14 +196,14 @@ class Test_SecretKeyring(object):
         assert sec.get("foo2") is None
 
         # Remove non existant key:
-        with pytest.raises(ValueError, match="Key 'foo4' not",
-                           message="It should raise a ValueError"):
+        with pytest.raises(ValueError, match="Key 'foo4' not"):
             sec.delete("foo4")
+            pytest.fail("It should raise a ValueError")
 
         sec.delete("foo3")
         assert sec.get("foo3") is None
 
         # Remove non existant key:
-        with pytest.raises(ValueError, match="Key 'foo4' not",
-                           message="It should raise a ValueError"):
+        with pytest.raises(ValueError, match="Key 'foo4' not"):
             sec.delete("foo4")
+            pytest.fail("It should raise a ValueError")

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -121,7 +121,7 @@ NTk2YTEyMDIyYTM4ZDc3YjM3Mzk2OGNlMzc1Yg==
         # Test with a erroneous filename.
         sec = secrets.SecretIsbg(filename="", imapset=imapset)
         assert sec.get("foo") is None
-        with pytest.raises(EnvironmentError, match="\[Errno "):
+        with pytest.raises(EnvironmentError, match=r"\[Errno "):
             sec.set("foo", "boo")
             pytest.fail("A EnvironmentError should be raised.")
 
@@ -159,7 +159,7 @@ NTk2YTEyMDIyYTM4ZDc3YjM3Mzk2OGNlMzc1Yg==
         # Remove last key, it should delete the file:
         sec.delete("foo3")
         assert sec.get("foo3") is None
-        with pytest.raises(EnvironmentError, match="\[Errno 2\]"):
+        with pytest.raises(EnvironmentError, match=r"\[Errno 2\]"):
             os.remove("tmp.txt")
             pytest.fail("A EnvironmentError should be raised.")
 

--- a/tests/test_spamproc.py
+++ b/tests/test_spamproc.py
@@ -74,9 +74,9 @@ def test_learn_mail():
         assert ret is 6, "Mail should be already learned."
     else:
         # We forget the mail:
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
+        with pytest.raises(OSError, match="No such file"):
             spamproc.learn_mail(mail, 'forget')
+            pytest.fail("Should rise OSError.")
 
 
 def test_test_mail():
@@ -97,12 +97,12 @@ def test_test_mail():
         assert score == u'-9999', 'It should return a error'
         assert code is None, 'It should return a error'
     else:
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
+        with pytest.raises(OSError, match="No such file"):
             spamproc.test_mail(mail, True)
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
+            pytest.fail("Should rise OSError.")
+        with pytest.raises(OSError, match="No such file"):
             spamproc.test_mail(mail, cmd=["spamc", "-E", "--max-size=268435450"])
+            pytest.fail("Should rise OSError.")
 
     if cmd_exists('spamassassin'):
         # We test the mail with spamassassin:
@@ -115,20 +115,20 @@ def test_test_mail():
         assert score == u'-9999', 'It should return a error'
         assert code is None, 'It should return a error'
     else:
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
+        with pytest.raises(OSError, match="No such file"):
             spamproc.test_mail(mail, False)
-        with pytest.raises(OSError, match="No such file",
-                           message="Should rise OSError."):
+            pytest.fail("Should rise OSError.")
+        with pytest.raises(OSError, match="No such file"):
             spamproc.test_mail(mail, cmd=["spamassassin", "--exit-code"])
+            pytest.fail("Should rise OSError.")
 
     # We try a random cmds (existant and unexistant):
     score, code, spamassassin_result = spamproc.test_mail("", cmd=["echo"])
     assert score == u'-9999', 'It should return a error'
     assert code is None, 'It should return a error'
-    with pytest.raises(OSError, match="No such file",
-                       message="Should rise OSError."):
+    with pytest.raises(OSError, match="No such file"):
         spamproc.test_mail(mail, cmd=["_____fooo___x_x"])
+        pytest.fail("Should rise OSError.")
 
 
 class Test_Sa_Learn(object):
@@ -179,9 +179,9 @@ class Test_SpamAssassin(object):
         for k in self._kwargs:
             assert k in dir(sa)
 
-        with pytest.raises(TypeError, match="Unknown keyword",
-                           message="Should rise a error."):
+        with pytest.raises(TypeError, match="Unknown keyword"):
             sa = spamproc.SpamAssassin(imap2=0)
+            pytest.fail("Should rise a error.")
 
     def test_cmd_save(self):
         """Test cmd_save."""
@@ -211,13 +211,13 @@ class Test_SpamAssassin(object):
     def test_learn_checks(self):
         """Test learn checks."""
         sa = spamproc.SpamAssassin()
-        with pytest.raises(isbg.ISBGError, match="Unknown learn_type",
-                           message="Should rise error."):
+        with pytest.raises(isbg.ISBGError, match="Unknown learn_type"):
             sa.learn('Spam', '', None, [])
+            pytest.fail("Should rise error.")
 
-        with pytest.raises(isbg.ISBGError, match="Imap is required",
-                           message="Should rise error."):
+        with pytest.raises(isbg.ISBGError, match="Imap is required"):
             sa.learn('Spam', 'ham', None, [])
+            pytest.fail("Should rise error.")
 
     def test_get_formated_uids(self):
         """Test get_formated_uids."""
@@ -256,9 +256,9 @@ class Test_SpamAssassin(object):
         sa = spamproc.SpamAssassin.create_from_isbg(sbg)
 
         # OSError required when it's run without spamassassin (travis-cl)
-        with pytest.raises((AttributeError, OSError, MessageError),
-                           message="Should rise error, IMAP not created."):
+        with pytest.raises((AttributeError, OSError, MessageError)):
             sa._process_spam(1, u"3/10\n", "", [], 0, "")
+            pytest.fail("Should rise error, IMAP not created.")
 
         sa.noreport = True
         sa.deletehigherthan = 2
@@ -268,6 +268,6 @@ class Test_SpamAssassin(object):
         """Test process_inbox."""
         sbg = isbg.ISBG()
         sa = spamproc.SpamAssassin.create_from_isbg(sbg)
-        with pytest.raises(AttributeError, match="has no attribute",
-                           message="Should rise error, IMAP not created."):
+        with pytest.raises(AttributeError, match="has no attribute"):
             sa.process_inbox([])
+            pytest.fail("Should rise error, IMAP not created.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,9 +54,9 @@ def test_hexof_dehexof():
     assert dehex == "P@*"
     assert utils.hexof(dehex) == "50402a"
     with pytest.raises(ValueError,
-                       match=repr("G") + " is not a valid hexadecimal digit",
-                       message="Not error or unexpected error message"):
+                       match=repr("G") + " is not a valid hexadecimal digit"):
         utils.dehexof("G")
+        pytest.fail("Not error or unexpected error message")
     dehex = utils.dehexof("50402a")
     assert dehex == "P@*"
     assert utils.hexof(dehex) == "50402a"
@@ -84,8 +84,9 @@ def test_score_from_mail():
     fmail = open('examples/spam.eml', 'rb')
     ftext = fmail.read()
     fmail.close()
-    with pytest.raises(AttributeError, message="Should rise AttributeError."):
+    with pytest.raises(AttributeError):
         ret = utils.score_from_mail(ftext.decode(errors='ignore'))
+        pytest.fail("Should rise AttributeError.")
     # With score:
     fmail = open('examples/spam.from.spamassassin.eml', 'rb')
     ftext = fmail.read()
@@ -120,22 +121,30 @@ def test_shorten():
         "Strings should be diferents."
 
     # Others:
-    with pytest.raises(TypeError, message="None should raise a TypeError."):
+    with pytest.raises(TypeError):
         utils.shorten(None, 8)
-    with pytest.raises(TypeError, message="None should raise a TypeError."):
+        pytest.fail("None should raise a TypeError.")
+    with pytest.raises(TypeError):
         utils.shorten(None, 7)
-    with pytest.raises(TypeError, message="None should raise a TypeError."):
+        pytest.fail("None should raise a TypeError.")
+    with pytest.raises(TypeError):
         utils.shorten(False, 8)
-    with pytest.raises(TypeError, message="None should raise a TypeError."):
+        pytest.fail("None should raise a TypeError.")
+    with pytest.raises(TypeError):
         utils.shorten(True, 7)
-    with pytest.raises(TypeError, message="int should raise a TypeError."):
+        pytest.fail("None should raise a TypeError.")
+    with pytest.raises(TypeError):
         utils.shorten(1, 7)
-    with pytest.raises(TypeError, message="float should raise a TypeError."):
+        pytest.fail("int should raise a TypeError.")
+    with pytest.raises(TypeError):
         utils.shorten(1.0, 7)
-    with pytest.raises(ValueError, message="length should be at least 1."):
+        pytest.fail("float should raise a TypeError.")
+    with pytest.raises(ValueError):
         utils.shorten("123", 0)
-    with pytest.raises(TypeError, message="int should be not supported."):
+        pytest.fail("length should be at least 1.")
+    with pytest.raises(TypeError):
         assert utils.shorten([1, 2, 3], 2)
+        pytest.fail("int should be not supported.")
     assert utils.shorten(["111", "2", "3"], 3) == ["111", "2", "3"]
     assert utils.shorten(("111", "2", "3"), 3) == ("111", "2", "3")
 


### PR DESCRIPTION
This PR:

* tests ISBG with python3.7
* fixes deprecation warnings
* removes a test I don't think is useful and that failed Travis for no good reason.