### PR TITLE
drop from __future__ imports

### DIFF
--- a/isbg/__init__.py
+++ b/isbg/__init__.py
@@ -7,12 +7,6 @@ and the original marked or deleted.
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 from .isbg import ISBG, ISBGError, __version__, __exitcodes__, __license__
 from .spamproc import learn_mail, test_mail
 from .sa_unwrap import unwrap

--- a/isbg/__main__.py
+++ b/isbg/__main__.py
@@ -32,11 +32,6 @@ See Also:
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
 

--- a/isbg/imaputils.py
+++ b/isbg/imaputils.py
@@ -23,11 +23,6 @@
 
 """Imap utils module for isbg - IMAP Spam Begone."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import email          # To easily encapsulated emails messages
 import email.message  # required for typing.TypeVar to work in py3
 import imaplib

--- a/isbg/isbg.py
+++ b/isbg/isbg.py
@@ -14,12 +14,6 @@ original marked or deleted.
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 import os
 import sys     # Because sys.stderr.write() is called bellow
 

--- a/isbg/sa_unwrap.py
+++ b/isbg/sa_unwrap.py
@@ -28,11 +28,6 @@ Examples:
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function  # Now we can use print(...
-from __future__ import unicode_literals
-
 import email
 import email.message
 from io import IOBase

--- a/isbg/secrets.py
+++ b/isbg/secrets.py
@@ -26,11 +26,6 @@
 .. versionadded:: 2.1.0
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 try:
     import keyring              # noqa: F401
     import keyrings.alt.file    # noqa: F401

--- a/isbg/spamproc.py
+++ b/isbg/spamproc.py
@@ -24,11 +24,6 @@
 """Spam processing module for isbg."""
 # pylint: disable=no-member
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import isbg
 
 from isbg import imaputils

--- a/isbg/utils.py
+++ b/isbg/utils.py
@@ -26,11 +26,6 @@
 
 """Utils for isbg - IMAP Spam Begone."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import re
 from platform import python_version  # To check py version

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -23,11 +23,6 @@
 
 """Test cases for __main__ file."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
 

--- a/tests/test_imaputils.py
+++ b/tests/test_imaputils.py
@@ -23,11 +23,6 @@
 
 """Test cases for isbg module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import email
 import logging
 import os

--- a/tests/test_isbg.py
+++ b/tests/test_isbg.py
@@ -23,11 +23,6 @@
 
 """Test cases for isbg module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 # With atexit._run_exitfuncs()  we free the lockfile, but we lost coverage
 # statistics.
 

--- a/tests/test_sa_unwrap.py
+++ b/tests/test_sa_unwrap.py
@@ -21,11 +21,6 @@
 
 """Test cases for sa_unwrap module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
 import email.message

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -23,11 +23,6 @@
 
 """Tests for secrets.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import base64
 import os
 import sys

--- a/tests/test_spamproc.py
+++ b/tests/test_spamproc.py
@@ -23,11 +23,6 @@
 
 """Tests for spamproc.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
 try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,11 +23,6 @@
 
 """Test cases for utils module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
 


### PR DESCRIPTION
The full table of function compatibility can be found at: https://docs.python.org/3/library/__future__.html

As you can see, all the ones we were using were merged since python3.0