### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ autodoc_default_flags = ['members']
 autodoc_docstring_signature = False
 autodoc_mock_imports = []
 autodoc_warningiserror = True
+autodoc_default_options = {'exclude-members': 'xdg_cache_home'}
 
 # Enable nitpicky mode - which ensures that all references in the docs
 # resolve.


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) we noticed that isbg could not be built reproducibly.

This is because it embeds the value of `xdg_cache_home` in the documentation which invariably points to something like `/home/lamby/.cache` and thus varies depending on the build user.

This was originally filed in Debian as [#944520](https://bugs.debian.org/944520).